### PR TITLE
fix: fixed import statement

### DIFF
--- a/src/shx.js
+++ b/src/shx.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import shell from 'shelljs';
-import printCmdRet from './printCmdRet';
+import { printCmdRet } from './printCmdRet';
 
 export const EXIT_CODES = {
   SHX_ERROR: 27, // https://xkcd.com/221/


### PR DESCRIPTION
Running `cli.js` from current `master` branch:

```
shx|master ⇒ npm run build && ./lib/cli.js pwd

> shx@0.0.1 prebuild /Users/scott/Documents/sites/shx
> rimraf lib


> shx@0.0.1 build /Users/scott/Documents/sites/shx
> babel src -d lib

src/cli.js -> lib/cli.js
src/printCmdRet.js -> lib/printCmdRet.js
src/shx.js -> lib/shx.js
/Users/scott/Documents/sites/shx/lib/shx.js:58
  if (fnName !== 'echo') (0, _printCmdRet2.default)(ret);
                                                   ^

TypeError: (0 , _printCmdRet2.default) is not a function
    at shx (/Users/scott/Documents/sites/shx/lib/shx.js:58:52)
    at Object.<anonymous> (/Users/scott/Documents/sites/shx/lib/cli.js:8:27)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:146:18)
    at node.js:404:3
```

With fix applied:
```
shx|master⚡ ⇒ npm run build && ./lib/cli.js pwd

> shx@0.0.1 prebuild /Users/scott/Documents/sites/shx
> rimraf lib


> shx@0.0.1 build /Users/scott/Documents/sites/shx
> babel src -d lib

src/cli.js -> lib/cli.js
src/printCmdRet.js -> lib/printCmdRet.js
src/shx.js -> lib/shx.js
{ [String: '/Users/scott/Documents/sites/shx']
  stdout: '/Users/scott/Documents/sites/shx',
  stderr: '',
  code: 0,
  to: [Function],
  toEnd: [Function],
  cat: [Function],
  head: [Function],
  sed: [Function],
  sort: [Function],
  tail: [Function],
  grep: [Function],
  exec: [Function] }
```

ShellJS is awesome and I have been **hunting** for a project exactly like shx.  I'll keep an eye on open issues and see if there are ways for me to make more meaningful contributions :) 