### PR TITLE
fix: trailing newlines are now consistent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,14 @@
     "vars-on-top": 0,
     "spaced-comment": [2, "always", { "markers": ["@", "@include"], "exceptions": ["@"] }],
     "no-param-reassign": 1,
-    "no-console": 0
+    "no-console": 0,
+    "curly": 0,
+    "no-var": 2,
+    "prefer-const": 2,
+    "new-cap": [2, {
+      "capIsNewExceptions": [
+        "ShellString"
+      ]}
+    ]
   }
 }

--- a/src/printCmdRet.js
+++ b/src/printCmdRet.js
@@ -2,16 +2,15 @@
 // Invoke this *REGARDLESS* of what the command returns, it will figure it out.
 export const printCmdRet = (ret) => {
   if (!ret) return;
+  if (typeof ret === 'boolean') return; // don't print this
 
-  // This is way to complicated. It should get much easier once shelljs/shelljs#356 is fixed.
-  if (ret.stdout && ret.stderr) {
-    if (ret.stdout) console.log(ret.stdout);
-    if (ret.stderr) console.error(ret.stderr);
-  } else if (ret.output) {
-    console.log(ret.output);
+  if (typeof ret.stdout === 'string') {
+    process.stdout.write(ret.stdout);
   } else if (Array.isArray(ret)) {
-    console.log(ret.join('\n'));
+    process.stdout.write(ret.join('\n'));
+    if (ret.length > 0)
+      console.log(); // an extra newline
   } else {
-    console.log(ret);
+    process.stdout.write(ret);
   }
 };

--- a/src/shx.js
+++ b/src/shx.js
@@ -34,11 +34,18 @@ export const shx = (argv) => {
     return EXIT_CODES.SHX_ERROR;
   }
 
-  const ret = shell[fnName](...args);
-  const code = ret.hasOwnProperty('code') && ret.code;
+  let ret = shell[fnName](...args);
+  if (ret === null)
+    ret = shell.ShellString('', '', 1);
+  let code = ret.hasOwnProperty('code') && ret.code;
+
+  if ((fnName === 'pwd' || fnName === 'which') && !ret.endsWith('\n') && ret.length > 1)
+    ret += '\n';
 
   // echo already prints
   if (fnName !== 'echo') printCmdRet(ret);
+  if (typeof ret === 'boolean')
+    code = ret ? 0 : 1;
 
   if (typeof code === 'number') {
     return code;


### PR DESCRIPTION
This fixes the fiasco raised by shelljs/shelljs#420. This should be compatible with the current state of ShellJS and should *also* work with any reasonable response to that issue in ShellJS.

Stuff that used to be broken:

 - Printing any command would look like junk (there was a simple logic error). It would print the internal representation of ShellStrings, not the string value.

Once the logic error was fixed, there were all sorts of other bugs:

 - error messages would be printed twice
 - `shx cat package.json` added an extra newline (also with `sort`, `head`, `tail`, and probably many others)
 - `test -f package.json` would output `true` to the console (it should be silent, just return a "true" exit code)
 - `test -d package.json` would output nothing, but would exit with status `0` (now it exits with status `1`)

All this stuff is now fixed by this PR.

There's one more bug, which IMO should get fixed on ShellJS's side. `shx ls empty/` (`empty/` is an empty directory) outputs `\n\n` when it should output `\n`. Appending the newline is  only correct for arrays of length \> 1. This PR fixes the bug for other arrays though (so you can try it out with older versions of `ls()` that don't have the `.stdout` property).