### PR TITLE
Build on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "shx": "lib/cli.js"
   },
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "prebuild": "rimraf lib",
     "build": "babel src -d lib",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint --silent -- --fix",
     "lint:watch": "watch 'npm run lint --silent' src",
-    "postinstall": "npm run build",
+    "prepublish": "npm run build",
     "pretest": "npm run lint",
     "test": "ava",
     "test:watch": "watch 'npm test --silent' src test"


### PR DESCRIPTION
Once we publish to `npm`, the current package would perform a build on the user's machine during an `npm i`.  This PR will ensure the build assets are published to NPM beforehand.  This way, there is no build necessary locally.  The built `lib` folder will exist, but only on NPM, still not in our codebase.