### PR TITLE
chore(package.json): add test coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ npm-debug.log*
 node_modules
 tmp
 lib
+.nyc_output
+coverage
 
 # Linux
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ os:
   - osx
 script:
   - npm test
-
+after_success:
+  - npm run test:coverage
+  - cat ./coverage/lcov.info | ./node_modules/codecov/bin/codecov
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublish": "npm run build",
     "posttest": "npm run lint --silent",
     "test": "mocha",
+    "test:coverage": "nyc --reporter=text --reporter=lcov mocha",
     "test:watch": "concurrently -rk 'npm run test --silent -- -w' 'npm run lint:watch'"
   },
   "repository": {
@@ -50,12 +51,14 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
+    "codecov": "^1.0.1",
     "concurrently": "^2.0.0",
     "dirty-chai": "^1.2.2",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.1",
     "eslint-plugin-react": "^3.16.1",
     "mocha": "^2.4.5",
+    "nyc": "^6.4.0",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
closes #19 

This PR adds `test:coverage` npm script to run test coverage, as well as including setup to codecov coverage (https://codecov.io/) after travis CI completes. Repo owner need to enable repository watching in codecov to collect coverage data.

Actual results can be looked at https://codecov.io/gh/kwonoj/shx/src/880e389d000d60080a65cc9dee7fbed69bc72b8d/src/shx.js , ran against forked repo.

