### PR TITLE
chore: update shelljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "watch": "^0.17.1"
   },
   "dependencies": {
-    "shelljs": "github:shelljs/shelljs"
+    "shelljs": "^0.7.0"
   }
 }


### PR DESCRIPTION
shelljs v0.7 just got released, so this should make things more stable for shx.