### PR TITLE
chore(CI): update to node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 env:
   - NODE_VERSION="4"
   - NODE_VERSION="5"
+  - NODE_VERSION="6"
 
 # keep this blank to make sure there are no before_install steps
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: '6'
     - nodejs_version: '5'
     - nodejs_version: '4'
 


### PR DESCRIPTION
Does what it says. I'm trying to bump appveyor up to v6 again, but if it doesn't work, I'll just take out that change.