### PR TITLE
Initial release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Releasing
+
+On the latest clean `master`:
+
+```
+npm run release:major
+npm run release:minor
+npm run release:patch
+```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "lint:watch": "watch 'npm run lint --silent' src test",
     "prepublish": "npm run build",
     "posttest": "npm run lint --silent",
+    "release:major": "bash scripts/release.sh major",
+    "release:minor": "bash scripts/release.sh minor",
+    "release:patch": "bash scripts/release.sh patch",
     "test": "nyc --reporter=text --reporter=lcov mocha",
     "test:watch": "concurrently -rk 'npm run test --silent -- -w' 'npm run lint:watch'"
   },

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# require npm user
+# bump package version
+# commit
+# create tag
+# push commit & tag
+# publish
+
+usage() {
+  echo ""
+  echo "  Usage: bash $0 <major|minor|patch>"
+}
+
+run() {
+  local version=$1
+  local collaborators=$(npm access ls-collaborators)
+  local npm_user=$(npm whoami 2>/dev/null || "false")
+  local is_collaborator=$(echo "$collaborators" | grep ".*$npm_user.*:.*write.*" && "true" || "false")
+
+  if [[ "$npm_user" ]]; then
+    if [[ "$is_collaborator" ]]; then
+      echo "Publishing new $version version as $npm_user."
+      echo ""
+      npm version ${version}
+      git push
+      git push --follow-tags
+      npm publish
+    else
+      echo "$npm_user does not have NPM write access. Request access from one of these fine folk:"
+      echo ""
+      npm owner ls
+    fi
+  else
+    echo "You must be logged in to NPM to publish, run \"npm login\" first."
+  fi
+}
+
+case $1 in
+  "major" | "minor" | "patch")
+    run $1
+  ;;
+
+  *)
+    usage
+    exit 1
+  ;;
+esac


### PR DESCRIPTION
This PR will conclude any open issues.  Folks are ready to use it (#29 #40) and I believe we ready to let them start.

I've added release scripts that are battle tested and a README snippet on how to use them.  Once this PR is ready, we'll just have to run this to release the first `v0.1.0` to NPM:

```shell
npm run release:minor
```

- [ ] add npm owner `nfischer`
- [ ] add npm owner `ariporad`

Closes #40.