### PR TITLE
refactor: remove babel-polyfill dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "watch": "^0.17.1"
   },
   "dependencies": {
-    "babel-polyfill": "^6.8.0",
     "shelljs": "^0.7.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import 'babel-polyfill';
 import { shx } from './shx';
 
 process.exit(shx(process.argv));

--- a/src/shx.js
+++ b/src/shx.js
@@ -29,7 +29,7 @@ export const shx = (argv) => {
   if (typeof shell[fnName] !== 'function') {
     console.error(`Error: Invalid ShellJS command: ${fnName}.`);
     return EXIT_CODES.SHX_ERROR;
-  } else if (CMD_BLACKLIST.includes(fnName)) {
+  } else if (CMD_BLACKLIST.indexOf(fnName) > -1) {
     console.error(`Warning: shx ${fnName} is not supported`);
     return EXIT_CODES.SHX_ERROR;
   }

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -1,23 +1,63 @@
 import * as shxModule from '../../src/shx';
 
 const shx = sandbox.spy(shxModule, 'shx');
+let stdout = '';
+
+const mockConsoleLog = (...msgs) => {      // mock console.log
+  stdout += `${msgs.join(' ')}\n`;
+  return undefined;
+};
+
+const mockStdoutWrite = (msg) => {      // mock process.stdout.write
+  stdout += msg;
+  return true;
+};
 
 // Run the cli with args as argv
 const cli = (...args) => {
   const oldArgv = process.argv;     // store original argv
+  const oldConsoleLog = console.log;
+  const oldStdoutWrite = process.stdout.write;
+  stdout = '';
   process.argv = ['', '', ...args]; // mock argv
+  console.log = mockConsoleLog;
+  process.stdout.write = mockStdoutWrite;
+
   sandbox.stub(process, 'exit');    // prevent cli from exiting test process
 
   require('../../src/cli');         // run cli
 
   process.exit.restore();           // restore stuff
   process.argv = oldArgv;
+  console.log = oldConsoleLog;
+  process.stdout.write = oldStdoutWrite;
+
+  delete require.cache[require.resolve('../../src/cli')]; // invalidate cache
+  return stdout;
 };
 
 describe('cli', () => {
   it('calls shx', () => {
     shx.should.have.not.been.called();
-    cli('echo');
+    const output = cli('echo');
+    output.should.equal('\n');
     shx.should.have.been.called();
+  });
+
+  it('outputs to stdout', () => {
+    const output = cli('echo', 'hello', 'world');
+    output.should.equal('hello world\n');
+  });
+
+  it('appends a newline for pwd', () => {
+    const output = cli('pwd');
+    output[output.length - 1].should.equal('\n');
+  });
+
+  it('works for commands with no output', () => {
+    let output = cli('cp', 'README.md', 'deleteme');
+    output.should.equal('');
+    output = cli('rm', 'deleteme'); // cleanup
+    output.should.equal('');
   });
 });


### PR DESCRIPTION
Removes babel-polyfill as a dependency (as brought up [here](https://github.com/shelljs/shx/issues/43#issuecomment-216674099)) and (as far as I can tell) works on node v4+.

If I missed any methods that should be changed, please let me know.