### PR TITLE
Add codecov badge and switch to flat styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Shx
 
-[![Travis](https://img.shields.io/travis/shelljs/shx.svg)](https://travis-ci.org/shelljs/shx)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/v3637gm5ftc72ms4/branch/master?svg=true)](https://ci.appveyor.com/project/ariporad/shx/branch/master)
+[![Travis](https://img.shields.io/travis/shelljs/shx/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs/shx)
+[![AppVeyor](https://img.shields.io/appveyor/ci/ariporad/shx/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/ariporad/shx/branch/master)
+[![Codecov](https://img.shields.io/codecov/c/github/shelljs/shx/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs/shx)
+
 
 `shx` is a wrapper around [ShellJS](https://github.com/shelljs/shelljs) Unix
 commands, providing an easy solution for simple Unix-like, cross-platform


### PR DESCRIPTION
Adds coverage badge.

Also moves to modern and consistent flat style with shields.io.  We avoided this last time due to the lack of distinction between travis and appveyor badges.  I've changed the `label` on those build badges to be `[unix: passing]` and `[windows: passing]` to show the difference.

![image](https://cloud.githubusercontent.com/assets/5067638/15033067/fc923d78-121b-11e6-9db9-d515a8a87f42.png)
