### PR TITLE
chore(changelog): create and add script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Change Log
+
+## [Unreleased](https://github.com/shelljs/shx/tree/HEAD)
+
+[Full Changelog](https://github.com/shelljs/shx/compare/v0.1.1...HEAD)
+
+**Closed issues:**
+
+- Code coverage badge seems to show for latest \(passing\) PR, not for master branch [\#51](https://github.com/shelljs/shx/issues/51)
+
+**Merged pull requests:**
+
+- Allow npm owner releases [\#50](https://github.com/shelljs/shx/pull/50) ([levithomason](https://github.com/levithomason))
+- feat\(help\): add help command [\#49](https://github.com/shelljs/shx/pull/49) ([ariporad](https://github.com/ariporad))
+- Add codecov badge and switch to flat styles [\#47](https://github.com/shelljs/shx/pull/47) ([levithomason](https://github.com/levithomason))
+- test: improve test coverage [\#46](https://github.com/shelljs/shx/pull/46) ([nfischer](https://github.com/nfischer))
+- refactor: remove babel-polyfill dep [\#45](https://github.com/shelljs/shx/pull/45) ([nfischer](https://github.com/nfischer))
+- Add install instructions [\#42](https://github.com/shelljs/shx/pull/42) ([levithomason](https://github.com/levithomason))
+
+## [v0.1.1](https://github.com/shelljs/shx/tree/v0.1.1) (2016-05-03)
+[Full Changelog](https://github.com/shelljs/shx/compare/v0.1.0...v0.1.1)
+
+**Closed issues:**
+
+- Broken release: missing runtime dependencies [\#43](https://github.com/shelljs/shx/issues/43)
+
+**Merged pull requests:**
+
+- fix\(deps\): add babel-polyfill as a runtime dep [\#44](https://github.com/shelljs/shx/pull/44) ([nfischer](https://github.com/nfischer))
+
+## [v0.1.0](https://github.com/shelljs/shx/tree/v0.1.0) (2016-05-03)
+**Closed issues:**
+
+- Linter checks the code coverage directory [\#36](https://github.com/shelljs/shx/issues/36)
+- Codecov.io repo settings [\#35](https://github.com/shelljs/shx/issues/35)
+- No rimraf command [\#27](https://github.com/shelljs/shx/issues/27)
+- Unable to install with npm [\#24](https://github.com/shelljs/shx/issues/24)
+- Switch to Mocha [\#22](https://github.com/shelljs/shx/issues/22)
+- Setup coverage [\#19](https://github.com/shelljs/shx/issues/19)
+- Setup Travis [\#17](https://github.com/shelljs/shx/issues/17)
+- Unable to install as a dependency [\#16](https://github.com/shelljs/shx/issues/16)
+- Switch this to use shelljs as a git submodule \(for now\) [\#13](https://github.com/shelljs/shx/issues/13)
+- Consider shx REPL [\#12](https://github.com/shelljs/shx/issues/12)
+- cd can't work, so we should output a warning [\#6](https://github.com/shelljs/shx/issues/6)
+- echo outputs twice [\#5](https://github.com/shelljs/shx/issues/5)
+- Initial Discussion and TODOs for 1st release [\#1](https://github.com/shelljs/shx/issues/1)
+
+**Merged pull requests:**
+
+- Initial release [\#41](https://github.com/shelljs/shx/pull/41) ([levithomason](https://github.com/levithomason))
+- chore\(CI\): update to node v6 [\#39](https://github.com/shelljs/shx/pull/39) ([nfischer](https://github.com/nfischer))
+- Show test coverage on every run [\#38](https://github.com/shelljs/shx/pull/38) ([levithomason](https://github.com/levithomason))
+- chore\(lint\): don't lint coverage results [\#37](https://github.com/shelljs/shx/pull/37) ([ariporad](https://github.com/ariporad))
+- chore: update shelljs dependency [\#34](https://github.com/shelljs/shx/pull/34) ([nfischer](https://github.com/nfischer))
+- chore\(package.json\): add test coverage script [\#33](https://github.com/shelljs/shx/pull/33) ([kwonoj](https://github.com/kwonoj))
+- docs: update example in README [\#32](https://github.com/shelljs/shx/pull/32) ([nfischer](https://github.com/nfischer))
+- Switch to mocha [\#31](https://github.com/shelljs/shx/pull/31) ([levithomason](https://github.com/levithomason))
+- chore: add "Team" section to README [\#30](https://github.com/shelljs/shx/pull/30) ([nfischer](https://github.com/nfischer))
+- Add missing rimraf devDependency [\#28](https://github.com/shelljs/shx/pull/28) ([levithomason](https://github.com/levithomason))
+- Build on prepublish [\#25](https://github.com/shelljs/shx/pull/25) ([levithomason](https://github.com/levithomason))
+- chore\(CI\): add CI badges to README.md [\#23](https://github.com/shelljs/shx/pull/23) ([ariporad](https://github.com/ariporad))
+- fix: trailing newlines are now consistent [\#21](https://github.com/shelljs/shx/pull/21) ([nfischer](https://github.com/nfischer))
+- fix: fixed import statement [\#20](https://github.com/shelljs/shx/pull/20) ([scott113341](https://github.com/scott113341))
+- Use ShellJS GitHub dependency [\#15](https://github.com/shelljs/shx/pull/15) ([levithomason](https://github.com/levithomason))
+- Setup tests [\#14](https://github.com/shelljs/shx/pull/14) ([levithomason](https://github.com/levithomason))
+- Refactor to ES6 [\#10](https://github.com/shelljs/shx/pull/10) ([levithomason](https://github.com/levithomason))
+- Fix file locations and references [\#9](https://github.com/shelljs/shx/pull/9) ([levithomason](https://github.com/levithomason))
+- fix: blacklist certain commands [\#8](https://github.com/shelljs/shx/pull/8) ([nfischer](https://github.com/nfischer))
+- fix\(echo\): fix \#5 [\#7](https://github.com/shelljs/shx/pull/7) ([nfischer](https://github.com/nfischer))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prebuild": "rimraf lib",
     "build": "babel src -d lib",
     "build:watch": "npm run build -- -w",
+    "changelog": "bash scripts/changelog.sh",
     "dev": "concurrently -rk 'npm run build:watch' 'npm run lint:watch'",
     "lint": "eslint .",
     "lint:fix": "npm run lint --silent -- --fix",

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Creates a changelog for the current build and puts it in the root
+# Commits the changelog if it updated
+# Does not push commit
+
+run() {
+  echo "...generating changelog (be patient)"
+
+  curl -X POST -s "github-changelog-api.herokuapp.com/shelljs/shx" > CHANGELOG.md
+
+  local changelog_was_updated=false
+  for file in $(git ls-files --exclude-standard --modified --others); do
+    [[ ${file} == "CHANGELOG.md" ]] && changelog_was_updated=true
+  done
+
+  if ${changelog_was_updated}; then
+    echo "...committing updated changelog"
+    local current_user=$(git config user.name || echo "unknown")
+    git add CHANGELOG.md
+    git commit -m "docs(changelog): updated by $current_user [ci skip]"
+    echo "Done.  You can now 'git push' the updated changelog."
+  else
+    echo "CHANGELOG.md already up-to-date."
+  fi
+}
+
+run


### PR DESCRIPTION
Resolves #18.

The changelog and changelog commit in this PR were generated using the script.  See commit:
```
docs(changelog): updated by levithomason [ci skip]
```

## Generate / Update

```shell
› npm run changelog 

...generating changelog (be patient)
...committing updated changelog
Done.  You can now 'git push' the updated changelog.
```

## No Changes

When the the changelog is already up to date and the script is run:

```shell
› npm run changelog

...generating changelog (be patient)
CHANGELOG.md already up-to-date.
```

## Future PRs

Later, this script can be integrated into the CI process.  The repo/branch/user can be inferred from CI env vars at that time as well.   This just gets it started.