### PR TITLE
feat: --silent will silence error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ helloworld.txt
 sub
 
 $ shx rm -r sub                 # options work as well
+
+$ shx --silent ls fakeFileName  # silence error output
 ```
 
 All commands internally call the ShellJS corresponding function, guaranteeing

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "watch": "^0.18.0"
   },
   "dependencies": {
+    "minimist": "^1.2.0",
     "shelljs": "^0.7.0"
   }
 }

--- a/src/shx.js
+++ b/src/shx.js
@@ -28,11 +28,7 @@ export const shx = (argv) => {
   }
 
   // Set shell.config with parsed options
-  Object.keys(parsedArgs).forEach(key => {
-    if (parsedArgs.hasOwnProperty(key) && key !== '_') {
-      shell.config[key] = parsedArgs[key];
-    }
-  });
+  Object.assign(shell.config, parsedArgs);
   let ret = shell[fnName](...args);
   if (ret === null)
     ret = shell.ShellString('', '', 1);

--- a/src/shx.js
+++ b/src/shx.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import shell from 'shelljs';
+import minimist from 'minimist';
 import help from './help';
 import { CMD_BLACKLIST, EXIT_CODES } from './config';
 import { printCmdRet } from './printCmdRet';
@@ -7,7 +8,8 @@ import { printCmdRet } from './printCmdRet';
 shell.help = help;
 
 export const shx = (argv) => {
-  const [fnName, ...args] = argv.slice(2);
+  const parsedArgs = minimist(argv.slice(2), { stopEarly: true, boolean: true });
+  const [fnName, ...args] = parsedArgs._;
   if (!fnName) {
     console.error('Error: Missing ShellJS command name');
     console.error(help());
@@ -25,6 +27,12 @@ export const shx = (argv) => {
     return EXIT_CODES.SHX_ERROR;
   }
 
+  // Set shell.config with parsed options
+  Object.keys(parsedArgs).forEach(key => {
+    if (parsedArgs.hasOwnProperty(key) && key !== '_') {
+      shell.config[key] = parsedArgs[key];
+    }
+  });
   let ret = shell[fnName](...args);
   if (ret === null)
     ret = shell.ShellString('', '', 1);

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -111,4 +111,11 @@ describe('cli', () => {
     output.stdout.should.equal('');
     output.stderr.should.equal('');
   });
+
+  it('allows --silent to change config.silent', () => {
+    const output = cli('--silent', 'ls', 'fakeFileName');
+    output.stdout.should.equal('');
+    output.stderr.should.equal('');
+    output.code.should.equal(2);
+  });
 });


### PR DESCRIPTION
Fixes #61 

This works with anything supported by `shell.config`. So if you want to change `shell.config.foo` to the value `true` for the `ls` command, you can specify `shx --foo ls`.

`shx --silent ls` won't silence all output, only error output, since that's currently how `config.silent` works. If we want `shx` to work differently, I can modify this to do a special check for the `--silent` flag and also silence stdout.