### PR TITLE
chore: update shelljs-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "lint:watch": "watch 'npm run lint --silent' src test",
     "prepublish": "npm run build",
     "posttest": "npm run lint --silent",
-    "release:major": "release major",
-    "release:minor": "release minor",
-    "release:patch": "release patch",
+    "release:major": "shelljs-release major",
+    "release:minor": "shelljs-release minor",
+    "release:patch": "shelljs-release patch",
     "test": "nyc --reporter=text --reporter=lcov mocha",
     "test:watch": "concurrently -rk 'npm run test --silent -- -w' 'npm run lint:watch'"
   },
@@ -63,7 +63,7 @@
     "mocha": "^2.4.5",
     "nyc": "^6.4.0",
     "rimraf": "^2.5.2",
-    "shelljs-release": "^0.1.3",
+    "shelljs-release": "^0.2.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "watch": "^0.18.0"


### PR DESCRIPTION
Updates to the latest version, which has a namespaced CLI. Doesn't change anything else.