### PR TITLE
docs: add npm README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis](https://img.shields.io/travis/shelljs/shx/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs/shx)
 [![AppVeyor](https://img.shields.io/appveyor/ci/ariporad/shx/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/ariporad/shx/branch/master)
 [![Codecov](https://img.shields.io/codecov/c/github/shelljs/shx/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs/shx)
-
+[![npm (scoped)](https://img.shields.io/npm/v/shx.svg?style=flat-square)](https://www.npmjs.com/package/shx)
 
 `shx` is a wrapper around [ShellJS](https://github.com/shelljs/shelljs) Unix
 commands, providing an easy solution for simple Unix-like, cross-platform


### PR DESCRIPTION
This just adds the npm version badge for shx:

[![npm (scoped)](https://img.shields.io/npm/v/shx.svg?style=flat-square)](https://www.npmjs.com/package/shx)