### PR TITLE
fix: sed works with slashes in regex

### DIFF
--- a/src/shx.js
+++ b/src/shx.js
@@ -37,10 +37,13 @@ export const shx = (argv) => {
     newArgs = [];
     let lookingForSubstString = true;
     args.forEach((arg) => {
-      const match = arg.match(/^s\/(.*)\/(.*)\/(g?)$/);
+      const match = arg.match(/^s\/(.*[^\\])\/(.*[^\\])\/(g?)$/);
       if (match && lookingForSubstString) {
-        newArgs.push(new RegExp(match[1], match[3]));
-        newArgs.push(match[2]);
+        const regexString = match[1].replace(/\\\//g, '/');
+        const replacement = match[2].replace(/\\\//g, '/').replace(/\\./g, '.');
+        const regexFlags = match[3];
+        newArgs.push(new RegExp(regexString, regexFlags));
+        newArgs.push(replacement);
         lookingForSubstString = false;
       } else {
         newArgs.push(arg);

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -123,6 +123,7 @@ describe('cli', () => {
   describe('sed', () => {
     const testFileName1 = 'foo.txt';
     const testFileName2 = 's/weirdfile/name/g';
+    const testFileName3 = 'urls.txt';
     beforeEach(() => {
       // create test files
       shell.touch(testFileName1);
@@ -131,11 +132,15 @@ describe('cli', () => {
       shell.mkdir('-p', 's/weirdfile/name');
       shell.touch(testFileName2);
       shell.ShellString('foo\nfoosomething\nfoofoosomething\n').to(testFileName2);
+
+      shell.touch(testFileName3);
+      shell.ShellString('http://www.nochange.com\nhttp://www.google.com\n').to(testFileName3);
     });
 
     afterEach(() => {
       shell.rm('-f', testFileName1);
-      shell.rm('-rf', 's/');
+      shell.rm('-rf', 's/'); // For testFileName2
+      shell.rm('-f', testFileName3);
     });
 
     it('works with no /g and no -i', () => {
@@ -148,6 +153,16 @@ describe('cli', () => {
       const output = cli('sed', '-i', 's/foo/bar/g', testFileName1);
       output.stdout.should.equal('bar\nbarsomething\nbarbarsomething\n');
       shell.cat(testFileName1).stdout.should.equal('bar\nbarsomething\nbarbarsomething\n');
+    });
+
+    it('works with regexes conatining slashes', () => {
+      const output = cli(
+        'sed',
+        's/http:\\/\\/www\\.google\\.com/https:\\/\\/www\\.facebook\\.com/',
+        testFileName3
+      );
+      output.stdout.should.equal('http://www.nochange.com\nhttps://www.facebook.com\n');
+      shell.cat(testFileName3).stdout.should.equal('http://www.nochange.com\nhttp://www.google.com\n');
     });
 
     it('works with weird file names', () => {


### PR DESCRIPTION
This should make `shx sed` work a little bit better. Also, this should make the code a bit more readable. If you have any readability suggestions, chime in and I'll implement those.