### PR TITLE
feat: support for ShellJS plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp
 lib
 .nyc_output
 coverage
+.shxrc.json
 
 # Linux
 *~

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "nyc": "^6.4.0",
     "rimraf": "^2.5.2",
     "shelljs-changelog": "^0.2.0",
+    "shelljs-plugin-open": "^0.1.1",
     "shelljs-release": "^0.2.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
@@ -70,6 +71,6 @@
   },
   "dependencies": {
     "minimist": "^1.2.0",
-    "shelljs": "^0.7.0"
+    "shelljs": "^0.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "minimist": "^1.2.0",
+    "path-exists": "^3.0.0",
     "shelljs": "^0.7.3"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -14,3 +14,5 @@ export const CMD_BLACKLIST = [
   'exec',
   'ShellString',
 ];
+
+export const CONFIG_FILE = '.shxrc.json';

--- a/src/help.js
+++ b/src/help.js
@@ -1,10 +1,11 @@
 import shell from 'shelljs';
 import { CMD_BLACKLIST } from './config';
 
-const commandList = Object.keys(shell)
-  .filter(cmd => typeof shell[cmd] === 'function' && CMD_BLACKLIST.indexOf(cmd) === -1);
+export default () => {
+  const commandList = Object.keys(shell)
+    .filter(cmd => typeof shell[cmd] === 'function' && CMD_BLACKLIST.indexOf(cmd) === -1);
 
-const help = `
+  return `
 shx: A wrapper for shelljs UNIX commands.
 
 Usage: shx <command> [options]
@@ -23,5 +24,4 @@ Commands:
 
 ${commandList.map(cmd => `    - ${cmd}`).join('\n')}
 `;
-
-export default () => help;
+};

--- a/src/shx.js
+++ b/src/shx.js
@@ -5,7 +5,7 @@ import help from './help';
 import { CMD_BLACKLIST, EXIT_CODES, CONFIG_FILE } from './config';
 import { printCmdRet } from './printCmdRet';
 import path from 'path';
-import fs from 'fs';
+import pathExists from 'path-exists';
 
 shell.help = help;
 
@@ -20,7 +20,7 @@ export const shx = (argv) => {
 
   // Load ShellJS plugins
   const CONFIG_PATH = path.join(process.cwd(), CONFIG_FILE);
-  if (fs.existsSync(CONFIG_PATH)) {
+  if (pathExists.sync(CONFIG_PATH)) {
     let shxConfig;
     try {
       shxConfig = require(CONFIG_PATH);

--- a/src/shx.js
+++ b/src/shx.js
@@ -2,8 +2,10 @@
 import shell from 'shelljs';
 import minimist from 'minimist';
 import help from './help';
-import { CMD_BLACKLIST, EXIT_CODES } from './config';
+import { CMD_BLACKLIST, EXIT_CODES, CONFIG_FILE } from './config';
 import { printCmdRet } from './printCmdRet';
+import path from 'path';
+import fs from 'fs';
 
 shell.help = help;
 
@@ -14,6 +16,25 @@ export const shx = (argv) => {
     console.error('Error: Missing ShellJS command name');
     console.error(help());
     return EXIT_CODES.SHX_ERROR;
+  }
+
+  // Load ShellJS plugins
+  const CONFIG_PATH = path.join(process.cwd(), CONFIG_FILE);
+  if (fs.existsSync(CONFIG_PATH)) {
+    let shxConfig;
+    try {
+      shxConfig = require(CONFIG_PATH);
+    } catch (e) {
+      throw new Error(`Unable to read config file ${CONFIG_FILE}`);
+    }
+
+    (shxConfig.plugins || []).forEach((pluginName) => {
+      try {
+        require(pluginName);
+      } catch (e) {
+        throw new Error(`Unable to find plugin '${pluginName}'`);
+      }
+    });
   }
 
   // validate command


### PR DESCRIPTION
This adds support for ShellJS plugins. This can be used by creating a config file for shx, `.shxrc.json` in the root of your package (assuming that you'll be running `shx` via npm scripts). The file should be formatted as such:

```json
{
  "plugins": [
    "shelljs-plugin-foo"
  ]
}
```

This will load in the `shelljs-plugin-foo` plugin. This plugin must be required by the user as a dependency (or dev dependency) in the project, otherwise shx will fail for every command.

Once we officially support ShellJS plugins, we should update the README for shx to show plugin usage instructions.