### PR TITLE
chore: add npm downloads per month

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Travis](https://img.shields.io/travis/shelljs/shx/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs/shx)
 [![AppVeyor](https://img.shields.io/appveyor/ci/ariporad/shx/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/ariporad/shx/branch/master)
 [![Codecov](https://img.shields.io/codecov/c/github/shelljs/shx/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs/shx)
-[![npm (scoped)](https://img.shields.io/npm/v/shx.svg?style=flat-square)](https://www.npmjs.com/package/shx)
+[![npm version](https://img.shields.io/npm/v/shx.svg?style=flat-square)](https://www.npmjs.com/package/shx)
+[![npm downloads](https://img.shields.io/npm/dm/shx.svg?style=flat-square)](https://www.npmjs.com/package/shx)
 
 `shx` is a wrapper around [ShellJS](https://github.com/shelljs/shelljs) Unix
 commands, providing an easy solution for simple Unix-like, cross-platform


### PR DESCRIPTION
Adds a gitter badge for # of downloads per month. We could switch this to number of total downloads if you think that would be more interesting.