### PR TITLE
chore: add support for v0.11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c++
 sudo: false
 env:
+  - NODE_VERSION="0.11"
+  - NODE_VERSION="0.12"
+  - NODE_VERSION="1"
+  - NODE_VERSION="2"
+  - NODE_VERSION="3"
   - NODE_VERSION="4"
   - NODE_VERSION="5"
   - NODE_VERSION="6"

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "watch": "^0.18.0"
   },
   "dependencies": {
+    "es6-object-assign": "^1.0.3",
     "minimist": "^1.2.0",
-    "path-exists": "^3.0.0",
     "shelljs": "^0.7.3"
   }
 }

--- a/src/shx.js
+++ b/src/shx.js
@@ -5,7 +5,18 @@ import help from './help';
 import { CMD_BLACKLIST, EXIT_CODES, CONFIG_FILE } from './config';
 import { printCmdRet } from './printCmdRet';
 import path from 'path';
-import pathExists from 'path-exists';
+import fs from 'fs';
+import objAssign from 'es6-object-assign';
+objAssign.polyfill(); // modifies the global object
+
+const pathExistsSync = (filePath) => {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 shell.help = help;
 
@@ -20,7 +31,7 @@ export const shx = (argv) => {
 
   // Load ShellJS plugins
   const CONFIG_PATH = path.join(process.cwd(), CONFIG_FILE);
-  if (pathExists.sync(CONFIG_PATH)) {
+  if (pathExistsSync(CONFIG_PATH)) {
     let shxConfig;
     try {
       shxConfig = require(CONFIG_PATH);
@@ -78,7 +89,7 @@ export const shx = (argv) => {
     ret = shell.ShellString('', '', 1);
   let code = ret.hasOwnProperty('code') && ret.code;
 
-  if ((fnName === 'pwd' || fnName === 'which') && !ret.endsWith('\n') && ret.length > 1)
+  if ((fnName === 'pwd' || fnName === 'which') && !ret.match(/\n$/) && ret.length > 1)
     ret += '\n';
 
   // echo already prints


### PR DESCRIPTION
I don't think this is too much of a maintenance burden, and it lets us take advantage of shx from within shelljs, which I think is a big win.

If I missed anything, let me know.

This blocks shelljs/shelljs#525