### PR TITLE
feat: pass stdin along to ShellJS commands

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,17 +1,33 @@
 #!/usr/bin/env node
 import { shx } from './shx';
 
-const code = shx(process.argv);
+// `input` is null if we're running from a TTY, or a string of all stdin if
+// running from the right-hand side of a pipe
+const run = (input) => {
+  // Pass stdin to shx as the 'this' parameter
+  const code = shx.call(input, process.argv);
 
-// Make sure output is flushed before exiting the process. Please see:
-//  - https://github.com/shelljs/shx/issues/85
-//  - https://github.com/mochajs/mocha/issues/333
-let streamCount = 0;
-const streams = [process.stdout, process.stderr];
-streams.forEach(stream => {
-  streamCount++; // count each stream
-  stream.write('', () => {
-    streamCount--; // mark each stream as finished
-    if (streamCount === 0) process.exit(code);
+  // Make sure output is flushed before exiting the process. Please see:
+  //  - https://github.com/shelljs/shx/issues/85
+  //  - https://github.com/mochajs/mocha/issues/333
+  let streamCount = 0;
+  const streams = [process.stdout, process.stderr];
+  streams.forEach(stream => {
+    streamCount++; // count each stream
+    stream.write('', () => {
+      streamCount--; // mark each stream as finished
+      if (streamCount === 0) process.exit(code);
+    });
   });
-});
+};
+
+// ShellJS doesn't support input streams, so we have to collect all input first
+if (process.stdin.isTTY) {
+  // There's no stdin, so we can immediately invoke the ShellJS function
+  run(null);
+} else {
+  // Read all stdin first, and then pass that onto ShellJS
+  const chunks = [];
+  process.stdin.on('data', data => chunks.push(data));
+  process.stdin.on('end', () => run(chunks.join('')));
+}

--- a/src/shx.js
+++ b/src/shx.js
@@ -20,7 +20,7 @@ const pathExistsSync = (filePath) => {
 
 shell.help = help;
 
-export const shx = (argv) => {
+export function shx(argv) {
   const parsedArgs = minimist(argv.slice(2), { stopEarly: true, boolean: true });
   const [fnName, ...args] = parsedArgs._;
   if (!fnName) {
@@ -59,6 +59,8 @@ export const shx = (argv) => {
     return EXIT_CODES.SHX_ERROR;
   }
 
+  const input = this !== null ? new shell.ShellString(this) : null;
+
   // Set shell.config with parsed options
   Object.assign(shell.config, parsedArgs);
 
@@ -81,9 +83,9 @@ export const shx = (argv) => {
         newArgs.push(arg);
       }
     });
-    ret = shell[fnName](...newArgs);
+    ret = shell[fnName].apply(input, newArgs);
   } else {
-    ret = shell[fnName](...args);
+    ret = shell[fnName].apply(input, args);
   }
   if (ret === null)
     ret = shell.ShellString('', '', 1);
@@ -104,4 +106,4 @@ export const shx = (argv) => {
   }
 
   return EXIT_CODES.SUCCESS;
-};
+}

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -1,30 +1,58 @@
-export let stdout = '';
-export let stderr = '';
+let stdoutValue = '';
+let stderrValue = '';
+let stdinValue = null;
 
-export const consoleLog = (...msgs) => {      // mock console.log
-  stdout += `${msgs.join(' ')}\n`;
+const oldConsoleLog = console.log;
+const oldConsoleError = console.error;
+const oldStdoutWrite = process.stdout.write;
+const oldProcessExit = process.exit;
+
+const consoleLog = (...msgs) => {      // mock console.log
+  stdoutValue += `${msgs.join(' ')}\n`;
 };
 
-export const consoleError = (...msgs) => {    // mock console.error
-  stderr += `${msgs.join(' ')}\n`;
+const consoleError = (...msgs) => {    // mock console.error
+  stderrValue += `${msgs.join(' ')}\n`;
 };
 
-export const stdoutWrite = (msg) => {         // mock process.stdout.write
-  stdout += msg;
+const stdoutWrite = (msg) => {         // mock process.stdoutValue.write
+  stdoutValue += msg;
   return true;
 };
 
-export const processExit = (retCode) => {     // mock process.exit
+const processExit = (retCode) => {     // mock process.exit
   const e = { msg: 'process.exit was called',
               code: retCode || 0,
   };
   throw e;
 };
 
-export const getStdout = () => stdout;
-export const getStderr = () => stderr;
+const resetValues = () => {
+  stdoutValue = '';
+  stderrValue = '';
+};
 
-export const resetValues = () => {
-  stdout = '';
-  stderr = '';
+export const stdout = () => stdoutValue;
+export const stderr = () => stderrValue;
+export const stdin = (val) => {
+  // If called with no arg, return the mocked stdin. Otherwise set stdin to that
+  // arg
+  if (val === undefined) return stdinValue;
+  stdinValue = val;
+  return null;
+};
+
+export const init = () => {
+  resetValues();
+  console.log = consoleLog;
+  console.error = consoleError;
+  process.stdout.write = stdoutWrite;
+  process.exit = processExit;
+};
+
+export const restore = () => {
+  console.log = oldConsoleLog;
+  console.error = oldConsoleError;
+  process.stdout.write = oldStdoutWrite;
+  process.exit = oldProcessExit;
 };


### PR DESCRIPTION
Read all of stdin and pass it to the underlying ShellJS command. This is also
adds support for mocking stdin during tests, and refactors the mock utilities.

Fixes #80

If @levithomason doesn't have time to review, I can just merge this in a day or two (assuming everything passes)