### PR TITLE
fix: only wait for stdin when appropriate

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 import { shx } from './shx';
+import minimist from 'minimist';
+import { shouldReadStdin } from './config';
+
+const parsedArgs = minimist(process.argv.slice(2), { stopEarly: true, boolean: true });
 
 // `input` is null if we're running from a TTY, or a string of all stdin if
 // running from the right-hand side of a pipe
@@ -22,12 +26,12 @@ const run = (input) => {
 };
 
 // ShellJS doesn't support input streams, so we have to collect all input first
-if (process.stdin.isTTY) {
-  // There's no stdin, so we can immediately invoke the ShellJS function
-  run(null);
-} else {
+if (shouldReadStdin(parsedArgs._)) {
   // Read all stdin first, and then pass that onto ShellJS
   const chunks = [];
   process.stdin.on('data', data => chunks.push(data));
   process.stdin.on('end', () => run(chunks.join('')));
+} else {
+  // There's no stdin, so we can immediately invoke the ShellJS function
+  run(null);
 }


### PR DESCRIPTION
Don't deadlock waiting for stdin during situations when stdin is not expected.

Fixes #95