### PR TITLE
fix: better regex support for sed

### DIFF
--- a/src/shx.js
+++ b/src/shx.js
@@ -62,7 +62,7 @@ export function shx(argv) {
     newArgs = [];
     let lookingForSubstString = true;
     args.forEach((arg) => {
-      const match = arg.match(/^s\/(.*[^\\])\/(.*[^\\])\/(g?)$/);
+      const match = arg.match(/^s\/((?:\\\/|[^\/])+)\/((?:\\\/|[^\/])*)\/(g?)$/);
       if (match && lookingForSubstString) {
         const regexString = match[1].replace(/\\\//g, '/');
         const replacement = match[2].replace(/\\\//g, '/').replace(/\\./g, '.');

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -311,6 +311,18 @@ describe('cli', () => {
         .equal('http://www.nochange.com\nhttp://www.google.com\n');
     });
 
+    it('works with empty replacement strings (with /g)', () => {
+      const output = cli('sed', 's/foo//g', testFileName1);
+      output.stdout.should
+        .equal('\nsomething\nsomething\n');
+    });
+
+    it('works with empty replacement strings (without /g)', () => {
+      const output = cli('sed', 's/foo//', testFileName1);
+      output.stdout.should
+        .equal('\nsomething\nfoosomething\n');
+    });
+
     it('works with weird file names', () => {
       const output = cli('sed', 's/foo/bar/', testFileName2);
       output.stdout.should.equal('bar\nbarsomething\nbarfoosomething\n');


### PR DESCRIPTION
Now works with using the empty string as a replacement string

Some details on allowed regexes (in unix `sed`):

* `s/foo/bar/`: the string must end in a slash (or with `/g` or something similar)
* `s/foo//`: the replacement string is allowed to be empty
* `s/a/b/`: the regex must be at least one character long
* `s/foo/bar\./g`: the `\.` is treated as a literal dot
* `s/foo/bar./g`: the `.` is also treated as a literal dot, when in the replacement string
* `s/foo./bar/g`: the `.` is **not** treated literally when in the regex string
* `s/foo\//bar\//g`: the `\/` is treated as a literal `/` in either string

Fixes #109