### PR TITLE
Handle input directly from npm scripts

### DIFF
--- a/src/shx.js
+++ b/src/shx.js
@@ -12,7 +12,11 @@ objAssign.polyfill(); // modifies the global object
 shell.help = help;
 
 export function shx(argv) {
-  const parsedArgs = minimist(argv.slice(2), { stopEarly: true, boolean: true });
+  argv.splice(0, 2);
+  if (argv[0] === '-c') {
+    argv = argv[1].split(' ');
+  }
+  const parsedArgs = minimist(argv, { stopEarly: true, boolean: true });
   const [fnName, ...args] = parsedArgs._;
   if (!fnName) {
     console.error('Error: Missing ShellJS command name');

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -61,6 +61,12 @@ describe('cli', () => {
     output.code.should.equal(EXIT_CODES.SHX_ERROR);
   });
 
+  it("handles -c 'input' directly from npm scripts", () => {
+    const output = cli('-c', 'echo hello world');
+    output.stdout.should.equal('hello world\n');
+    output.stderr.should.equal('');
+  });
+
   it('fails for unrecognized commands', () => {
     const output = cli('foobar');
     output.stdout.should.equal('');


### PR DESCRIPTION
Alleviate the need to prefix scipts with `shx`. Fixes #117.