### PR TITLE
chore(appveyor): do not use latest npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ version: '{build}'
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm -g install npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - node --version
   - npm --version


### PR DESCRIPTION
This changes appveyor from using the latest npm version to only using
the preinstalled npm version. This is safer, because it's guaranteed to
be a compatible version.

Fixes #132