### PR TITLE
fix(sed): better support for converting sed patterns

### DIFF
--- a/src/shx.js
+++ b/src/shx.js
@@ -26,7 +26,7 @@ const convertSedRegex = args => {
       const regexString = match[1].replace(/\\\//g, '/');
       const replacement = match[2].replace(/\\\//g, '/').replace(/\\./g, '.');
       const regexFlags = match[3];
-      if (!regexString) {
+      if (regexString === '') {
         // Unix sed gives an error if the pattern is the empty string, so we
         // forbid this case even though JavaScript's .replace() has well-defined
         // behavior.

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -334,7 +334,7 @@ describe('cli', () => {
     it('does not work with empty regex strings', () => {
       (() => {
         cli('sed', 's//foo/g', testFileName1);
-      }).should.throw(Error);
+      }).should.throw('Bad sed pattern (empty regex)');
     });
 
     it('works with empty replacement strings (without /g)', () => {


### PR DESCRIPTION
This PR does:

 1. Refactors sed-specific pattern-conversion logic. This logic converts
    a unix-style pattern (e.g., "s/foo/bar/") into the separate
    parameters expected by shell.sed() (e.g., new RegExp('foo'), 'bar').
    This builds the RegExp more carefully to avoid the issue with
    escaped slashes (as reported in #136).
 2. Explicitly checks for empty patterns and throws an error
    (previously, these would just silently fail conversion).
 3. Adds tests for the previous two cases.
 4. Refactors the sed tests to be more maintainable by saving file
    contents in test variables. No change in the logic of
    already-existing tests.

Fixes #136
Test: 'works with backslashes and forward slashes in pattern'
Test: 'does not work with empty regex strings'