### PR TITLE
test(coverage): fix coverage issues

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -42,7 +42,7 @@ export const shouldReadStdin = (args) => {
   });
   let requiredNumArgs = cmdInfo ? cmdInfo.minArgs : -1;
 
-  // If a non-boolean option is passed in, incrememnt the required argument
+  // If a non-boolean option is passed in, increment the required argument
   // count (this is the case for `-n` for `head` and `tail`)
   if (parsedArgs.n && (cmd === 'head' || cmd === 'tail')) {
     requiredNumArgs++;

--- a/src/shx.js
+++ b/src/shx.js
@@ -102,6 +102,7 @@ export function shx(argv) {
   if (typeof code === 'number') {
     return code;
   } else if (shell.error()) {
+    /* istanbul ignore next */
     return EXIT_CODES.CMD_FAILED;
   }
 

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -153,9 +153,10 @@ describe('cli', () => {
       shouldReadStdin(['grep', 'a.*z']).should.equal(true);
     });
 
-    it('reads stdin if only options are given', () => {
+    it('reads stdin if not enough arguments are given', () => {
       process.stdin.isTTY = undefined;
       shouldReadStdin(['head', '-n', '1']).should.equal(true);
+      shouldReadStdin(['tail', '-n', '1']).should.equal(true);
       shouldReadStdin(['grep', '-i', 'a.*z']).should.equal(true);
     });
 
@@ -214,6 +215,20 @@ describe('cli', () => {
       (() => {
         cli('ls');
       }).should.throw(Error);
+    });
+
+    it('does not load any plugins if config file lacks plugin section', () => {
+      const config = {
+        notplugins: [ // the plugins attribute is mandatory for loading plugins
+          'shelljs-plugin-open',
+        ],
+      };
+      shell.ShellString(JSON.stringify(config)).to(CONFIG_FILE);
+
+      const output = cli('help');
+      output.stderr.should.equal(''); // Runs successfully
+      output.stdout.should.match(/Usage/); // make sure help is printed
+      output.stdout.should.not.match(/- open/); // should *not* load the plugin
     });
 
     it('defends against malicious config files', () => {


### PR DESCRIPTION
These issues are pointed out by the latest version of nyc. Fixing these
issues brings us to 100% coverage (as of nyc@v12.0.2).

Fixes include:

 * ignore coverage for a condition we don't hit during testing
 * branch coverage for when we read stdin for commands with non-boolean
   options (e.g., head, tail)
 * branch coverage for plugin-behavior with config files lacking a
   plugin attribute

Issue #134