### PR TITLE
feat: add true and false as default commands

### DIFF
--- a/src/plugin-true-false.js
+++ b/src/plugin-true-false.js
@@ -1,0 +1,18 @@
+import plugin from 'shelljs/plugin';
+
+const shellTrue = () => '';
+
+const shellFalse = () => {
+  plugin.error('', { silent: true });
+};
+
+plugin.register('true', shellTrue, {
+  allowGlobbing: false,
+  wrapOutput: true,
+});
+
+plugin.register('false', shellFalse, {
+  allowGlobbing: false,
+  wrapOutput: true,
+});
+

--- a/src/shx.js
+++ b/src/shx.js
@@ -76,6 +76,9 @@ export function shx(argv) {
     });
   }
 
+  // Always load true-false plugin
+  require('./plugin-true-false');
+
   // validate command
   if (typeof shell[fnName] !== 'function') {
     console.error(`Error: Invalid ShellJS command: ${fnName}.`);

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -257,6 +257,20 @@ describe('cli', () => {
       output.stdout.should.match(/Usage/); // make sure help is printed
       output.stdout.should.match(/- open/); // help should include new command
     });
+
+    it('loads shx true by default', () => {
+      const output = cli('true');
+      output.stdout.should.equal('');
+      output.stderr.should.equal('');
+      output.code.should.equal(0);
+    });
+
+    it('loads shx false by default', () => {
+      const output = cli('false');
+      output.stdout.should.equal('');
+      output.stderr.should.equal('');
+      output.code.should.equal(1);
+    });
   });
 
   describe('ls', () => {


### PR DESCRIPTION
This implements true and false as a single plugin, and adds this plugin
by default to shx.

Fixes #105
Test: automated tests
Test: manual (works as expected)