### PR TITLE
feat: help command provides info on options

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,13 @@ export const CMD_BLACKLIST = [
   'ShellString',
 ];
 
+export const OPTION_BLACKLIST = [
+  'globOptions', // we don't have good control over globbing in the shell
+  'execPath', // we don't currently support exec
+  'bufLength', // we don't use buffers in shx
+  'maxdepth', // this option is undocumented, add this back if it makes sense
+];
+
 export const CONFIG_FILE = '.shxrc.json';
 
 export const SHELLJS_PIPE_INFO = {

--- a/src/help.js
+++ b/src/help.js
@@ -1,27 +1,42 @@
 import shell from 'shelljs';
-import { CMD_BLACKLIST } from './config';
+import { CMD_BLACKLIST, OPTION_BLACKLIST } from './config';
+
+// Global options defined directly in shx.
+const locallyDefinedOptions = ['version'];
+
+const shxOptions = Object.keys(shell.config)
+  .filter(key => typeof shell.config[key] !== 'function')
+  .filter(key => OPTION_BLACKLIST.indexOf(key) === -1)
+  .concat(locallyDefinedOptions)
+  .map(key => `    * --${key}`);
 
 export default () => {
+  // Note: compute this at runtime so that we have all plugins loaded.
   const commandList = Object.keys(shell)
-    .filter(cmd => typeof shell[cmd] === 'function' && CMD_BLACKLIST.indexOf(cmd) === -1);
+    .filter(cmd => typeof shell[cmd] === 'function')
+    .filter(cmd => CMD_BLACKLIST.indexOf(cmd) === -1)
+    .map(cmd => `    * ${cmd}`);
 
   return `
 shx: A wrapper for shelljs UNIX commands.
 
-Usage: shx <command> [options]
+Usage: shx [shx-options] <command> [cmd-options] [cmd-args]
 
 Example:
 
     $ shx ls .
     foo.txt
-    bar.txt
     baz.js
-    $ shx rm -rf *.txt
-    $ shx ls .
+    $ shx rm -rf *.txt && shx ls .
     baz.js
 
 Commands:
 
-${commandList.map(cmd => `    - ${cmd}`).join('\n')}
+${commandList.join('\n')}
+
+Shx Options (please see https://github.com/shelljs/shelljs for details on each
+option):
+
+${shxOptions.join('\n')}
 `;
 };

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -129,6 +129,15 @@ describe('cli', () => {
       output.stderr.should.equal('');
       output.code.should.equal(2);
     });
+
+    it('adds flags to the help output', () => {
+      const output = cli('help');
+      output.stderr.should.equal('');
+      output.stdout.should.match(/Usage/); // make sure help is printed
+      output.stdout.should.match(/\* --verbose/);
+      output.stdout.should.match(/\* --silent/);
+      output.stdout.should.match(/\* --version/);
+    });
   });
 
   describe('stdin', () => {
@@ -255,7 +264,7 @@ describe('cli', () => {
       const output = cli('help');
       output.stderr.should.equal('');
       output.stdout.should.match(/Usage/); // make sure help is printed
-      output.stdout.should.match(/- open/); // help should include new command
+      output.stdout.should.match(/\* open/); // help should include new command
     });
   });
 


### PR DESCRIPTION
This adds an 'shx-options' section the help output, covering options
such as --fatal, --silent, etc.

This also reformats existing help text slightly.

Fixes #101