### PR TITLE
chore: remove es6-object-assign dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,11 +1273,6 @@
         "event-emitter": "~0.3.5"
       }
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
-    },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "watch": "^0.18.0"
   },
   "dependencies": {
-    "es6-object-assign": "^1.0.3",
     "minimist": "^1.2.0",
     "shelljs": "^0.8.1"
   },

--- a/src/shx.js
+++ b/src/shx.js
@@ -6,8 +6,6 @@ import { CMD_BLACKLIST, EXIT_CODES, CONFIG_FILE } from './config';
 import { printCmdRet } from './printCmdRet';
 import path from 'path';
 import fs from 'fs';
-import objAssign from 'es6-object-assign';
-objAssign.polyfill(); // modifies the global object
 
 shell.help = help;
 


### PR DESCRIPTION
No change to logic, this just removes a dependency because we target
node >= v4 (which already supports Object.assign).

Fixes #146