### PR TITLE
chore(ci): switch to node language for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,14 @@
-language: c++
+language: node_js
 sudo: false
-env:
-  - NODE_VERSION="4"
-  - NODE_VERSION="5"
-  - NODE_VERSION="6"
-  - NODE_VERSION="7"
-  - NODE_VERSION="8"
-  - NODE_VERSION="9"
-  - NODE_VERSION="10"
+node_js:
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
 
-# keep this blank to make sure there are no before_install steps
-before_install:
-
-install:
-  - rm -rf ~/.nvm
-  - git clone https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - node --version
-  - npm install
 os:
   - linux
   - osx
@@ -26,5 +16,6 @@ script:
   - npm test
 after_success:
   - npm run codecov -- -f coverage/lcov.info
+
 notifications:
   email: false


### PR DESCRIPTION
See also: shelljs/shelljs#910

This switches Travis to use the node_js language. We originally used the
C++ language because OS X didn't properly support the node_js language
(so we had to do all setup manually). This is no longer the case.