### PR TITLE
chore: script to bump supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ os:
   - osx
 script:
   - npm test
+  - npm run check-node-support
 after_success:
   - npm run codecov -- -f coverage/lcov.info
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 commands, providing an easy solution for simple Unix-like, cross-platform
 commands in npm package scripts.
 
+`shx` is proudly tested on every node release since <!-- start minVersion -->`v4`<!-- stop minVersion -->!
+
 ## Difference Between ShellJS and shx
 
 - **ShellJS:** Good for writing long scripts, all in JS, running via NodeJS (e.g. `node myScript.js`).

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lib"
   ],
   "scripts": {
+    "check-node-support": "node scripts/check-node-support",
     "prebuild": "rimraf lib",
     "build": "babel src -d lib",
     "build:watch": "npm run build -- -w",
@@ -59,6 +60,7 @@
     "eslint": "^2.10.1",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.0",
+    "js-yaml": "^3.12.0",
     "mocha": "^5.2.0",
     "nyc": "^11.0.0",
     "rimraf": "^2.5.2",

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "node": true
+  },
+  "extends": "../.eslintrc.json",
+  "rules": {
+    "prefer-template": 0,
+    "no-var": 0
+  }
+}

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -26,9 +26,9 @@ function checkReadme(minNodeVersion) {
   }
 }
 
-function checkEngines(minNodeVersion, package) {
+function checkEngines(minNodeVersion, pack) {
   var expectedEnginesNode = '>=' + minNodeVersion;
-  if (package.engines.node !== expectedEnginesNode) {
+  if (pack.engines.node !== expectedEnginesNode) {
     var msg = 'Update package.json to fix the "engines" attribute';
     throw new Error(msg);
   }
@@ -70,8 +70,8 @@ function checkAppveyor(minNodeVersion, maxNodeVersion, appveyorYaml) {
 try {
   checkReadme(MIN_NODE_VERSION);
 
-  var package = require('../package.json');
-  checkEngines(MIN_NODE_VERSION, package);
+  var pack = require('../package.json');
+  checkEngines(MIN_NODE_VERSION, pack);
 
   var travisFileName = path.join(__dirname, '..', '.travis.yml');
   var travisYaml = yaml.safeLoad(shell.cat(travisFileName));

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+var assert = require('assert');
+var path = require('path');
+
+var yaml = require('js-yaml');
+
+var shell = require('shelljs');
+
+// This is the authoritative list of supported node versions.
+var MIN_NODE_VERSION = 4;
+var MAX_NODE_VERSION = 10;
+
+function checkReadme(minNodeVersion) {
+  var start = '<!-- start minVersion -->';
+  var stop = '<!-- stop minVersion -->';
+  var formattedMinVersion = '`v' + minNodeVersion + '`';
+  var expectedReadmeRegex = new RegExp(
+      start + '\\s*' + formattedMinVersion + '\\s*' + stop, '');
+  var readme = path.join(__dirname, '..', 'README.md');
+  var match = shell.grep(expectedReadmeRegex, readme);
+  if (!match.toString()) {
+    var msg = 'Update README to specify the min supported version. Look for "'
+        + start + '"';
+    throw new Error(msg);
+  }
+}
+
+function checkEngines(minNodeVersion, package) {
+  var expectedEnginesNode = '>=' + minNodeVersion;
+  if (package.engines.node !== expectedEnginesNode) {
+    var msg = 'Update package.json to fix the "engines" attribute';
+    throw new Error(msg);
+  }
+}
+
+function assertDeepEquals(arr1, arr2, msg) {
+  try {
+    assert.deepStrictEqual(arr1, arr2);
+  } catch (e) {
+    throw new Error(msg + '\n' + e);
+  }
+}
+
+function range(start, stop) {
+  var ret = [];
+  for (var i = start; i <= stop; i++) {
+    ret.push(i);
+  }
+  return ret;
+}
+
+function checkTravis(minNodeVersion, maxNodeVersion, travisYaml) {
+  var expectedTravisVersions = range(minNodeVersion, maxNodeVersion);
+  var msg = 'Check Travis node_js versions';
+  assertDeepEquals(travisYaml.node_js, expectedTravisVersions, msg);
+}
+
+function checkAppveyor(minNodeVersion, maxNodeVersion, appveyorYaml) {
+  var expectedAppveyorVersions = range(minNodeVersion, maxNodeVersion)
+      .map(function (num) {
+        return { nodejs_version: num.toString() };
+      })
+      .reverse(); // Arbitrarily, we store appveyor in reverse order.
+  var msg = 'Check Appveyor environment.matrix versions';
+  assertDeepEquals(appveyorYaml.environment.matrix, expectedAppveyorVersions,
+      msg);
+}
+
+try {
+  checkReadme(MIN_NODE_VERSION);
+
+  var package = require('../package.json');
+  checkEngines(MIN_NODE_VERSION, package);
+
+  var travisFileName = path.join(__dirname, '..', '.travis.yml');
+  var travisYaml = yaml.safeLoad(shell.cat(travisFileName));
+  checkTravis(MIN_NODE_VERSION, MAX_NODE_VERSION, travisYaml);
+
+  var appveyorFileName = path.join(__dirname, '..', 'appveyor.yml');
+  var appveyorYaml = yaml.safeLoad(shell.cat(appveyorFileName));
+  checkAppveyor(MIN_NODE_VERSION, MAX_NODE_VERSION, appveyorYaml);
+} catch (e) {
+  console.error('Please check the files which declare our Node version');
+  console.error('support, as something is out-of-sync. This script failed');
+  console.error('specificaly because:');
+  throw e;
+}

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -58,9 +58,7 @@ function checkTravis(minNodeVersion, maxNodeVersion, travisYaml) {
 
 function checkAppveyor(minNodeVersion, maxNodeVersion, appveyorYaml) {
   var expectedAppveyorVersions = range(minNodeVersion, maxNodeVersion)
-      .map(function (num) {
-        return { nodejs_version: num.toString() };
-      })
+      .map(num => ({ nodejs_version: num.toString() }))
       .reverse(); // Arbitrarily, we store appveyor in reverse order.
   var msg = 'Check Appveyor environment.matrix versions';
   assertDeepEquals(appveyorYaml.environment.matrix, expectedAppveyorVersions,


### PR DESCRIPTION
No change to node support, this just adds a script.

This adds a script to check that we correctly configure all supported
node versions, since we need to update quite a few spots (README.md,
package.json, travis, appveyor).

Issue shelljs/shelljs#873
Test: manual