### PR TITLE
Bump shelljs version to fix circular dependency warnings under Node.js v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "minimist": "^1.2.3",
-    "shelljs": "^0.8.1"
+    "shelljs": "^0.8.4"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
https://github.com/shelljs/shelljs/issues/991