### PR TITLE
Update shelljs to avoid circular dependency warnings on Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "minimist": "^1.2.3",
-    "shelljs": "^0.8.1"
+    "shelljs": "^0.8.4"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
https://github.com/shelljs/shelljs/pull/973 updated shelljs to prevent Node 14 from flooding the user with hundreds of lines that look like:
```
(node:117) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
(node:117) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
```

And it would be a good idea to make sure that the minimum version of shelljs matches that updated version.