### PR TITLE
refactor: rename "blacklist" -> "blocklist"

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,7 @@ export const EXIT_CODES = {
   SUCCESS: 0,
 };
 
-export const CMD_BLACKLIST = [
+export const CMD_BLOCKLIST = [
   'cd',
   'pushd',
   'popd',
@@ -17,7 +17,7 @@ export const CMD_BLACKLIST = [
   'ShellString',
 ];
 
-export const OPTION_BLACKLIST = [
+export const OPTION_BLOCKLIST = [
   'globOptions', // we don't have good control over globbing in the shell
   'execPath', // we don't currently support exec
   'bufLength', // we don't use buffers in shx

--- a/src/help.js
+++ b/src/help.js
@@ -1,12 +1,12 @@
 import shell from 'shelljs';
-import { CMD_BLACKLIST, OPTION_BLACKLIST } from './config';
+import { CMD_BLOCKLIST, OPTION_BLOCKLIST } from './config';
 
 // Global options defined directly in shx.
 const locallyDefinedOptions = ['version'];
 
 const shxOptions = Object.keys(shell.config)
   .filter(key => typeof shell.config[key] !== 'function')
-  .filter(key => OPTION_BLACKLIST.indexOf(key) === -1)
+  .filter(key => OPTION_BLOCKLIST.indexOf(key) === -1)
   .concat(locallyDefinedOptions)
   .map(key => `    * --${key}`);
 
@@ -14,7 +14,7 @@ export default () => {
   // Note: compute this at runtime so that we have all plugins loaded.
   const commandList = Object.keys(shell)
     .filter(cmd => typeof shell[cmd] === 'function')
-    .filter(cmd => CMD_BLACKLIST.indexOf(cmd) === -1)
+    .filter(cmd => CMD_BLOCKLIST.indexOf(cmd) === -1)
     .map(cmd => `    * ${cmd}`);
 
   return `

--- a/src/shx.js
+++ b/src/shx.js
@@ -3,7 +3,7 @@ import minimist from 'minimist';
 import path from 'path';
 import fs from 'fs';
 import help from './help';
-import { CMD_BLACKLIST, EXIT_CODES, CONFIG_FILE } from './config';
+import { CMD_BLOCKLIST, EXIT_CODES, CONFIG_FILE } from './config';
 import { printCmdRet } from './printCmdRet';
 
 shell.help = help;
@@ -81,7 +81,7 @@ export function shx(argv) {
     console.error(`Error: Invalid ShellJS command: ${fnName}.`);
     console.error(help());
     return EXIT_CODES.SHX_ERROR;
-  } else if (CMD_BLACKLIST.indexOf(fnName) > -1) {
+  } else if (CMD_BLOCKLIST.indexOf(fnName) > -1) {
     console.error(`Warning: shx ${fnName} is not supported`);
     console.error('Please run `shx help` for a list of commands.');
     return EXIT_CODES.SHX_ERROR;

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -73,7 +73,7 @@ describe('cli', () => {
     output.code.should.equal(EXIT_CODES.SHX_ERROR);
   });
 
-  it('fails for blacklisted commands', () => {
+  it('fails for blocked commands', () => {
     const output = cli('cd', 'src');
     output.stdout.should.equal('');
     output.stderr.should.match(/Warning: shx cd is not supported\n/);


### PR DESCRIPTION
No change to logic. This just renames "blacklist" to "blocklist" to use
more inclusive language.

Test: npm run test
Test: ./lib/cli.js exec (this is blocked, as expected)
Test: ./lib/cli.js help (does not mention blocked commands)