### PR TITLE
chore(ci): run tests up to node v16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
           - 12
           - 13
           - 14
+          - 15
+          - 16
         os:
           - ubuntu-latest
           - macos-latest

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -9,7 +9,7 @@ var shell = require('shelljs');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 6;
-var MAX_NODE_VERSION = 14;
+var MAX_NODE_VERSION = 16;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';


### PR DESCRIPTION
No change to logic. This adds node v15 and v16 to the CI testing.