### PR TITLE
chore: update CI to include v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           - 14
           - 15
           - 16
+          - 17
+          - 18
         os:
           - ubuntu-latest
           - macos-latest

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -9,7 +9,7 @@ var shell = require('shelljs');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 6;
-var MAX_NODE_VERSION = 16;
+var MAX_NODE_VERSION = 18;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';


### PR DESCRIPTION
No change to logic. This updates GitHub actions to test up through node
v18.