### PR TITLE
fix(lint): fixes import order lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-register": "^6.7.2",
     "concurrently": "^5.3.0",
     "eslint": "^5.16.0",
+    "eslint-import-resolver-node": "0.3.7",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.26.0",
     "js-yaml": "^3.12.0",

--- a/src/shx.js
+++ b/src/shx.js
@@ -1,7 +1,7 @@
-import shell from 'shelljs';
-import minimist from 'minimist';
 import path from 'path';
 import fs from 'fs';
+import shell from 'shelljs';
+import minimist from 'minimist';
 import help from './help';
 import { CMD_BLOCKLIST, EXIT_CODES, CONFIG_FILE } from './config';
 import { printCmdRet } from './printCmdRet';

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -1,6 +1,6 @@
-import * as shell from 'shelljs';
 import fs from 'fs';
 import path from 'path';
+import * as shell from 'shelljs';
 import { shx } from '../../src/shx';
 import { EXIT_CODES, CONFIG_FILE, shouldReadStdin } from '../../src/config';
 import * as mocks from '../mocks';


### PR DESCRIPTION
I can't reproduce these warnings locally, but these appear to be failing on CI. This is a speculative fix.