### PR TITLE
Bump GitHub workflow action to latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,13 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
       - run: npm run check-node-support
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
This PR bumps two GitHub workflow actions to their latest versions, as requested [here](https://github.com/shelljs/shelljs/pull/1136).