### PR TITLE
chore: switch to codecov v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       - run: npm run test
       - run: npm run check-node-support
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
No change to logic. This updates codecov/codecov-action to v4. This version supposedly has better support for external contributors working from repository forks.