### PR TITLE
chore(dependencies): update js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-import-resolver-node": "0.3.7",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.26.0",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^4.1.0",
     "mocha": "^6.2.3",
     "nyc": "^14.1.1",
     "rimraf": "^2.5.2",

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -65,7 +65,7 @@ try {
 
   var githubActionsFileName = path.join(__dirname, '..', '.github', 'workflows',
     'main.yml');
-  var githubActionsYaml = yaml.safeLoad(shell.cat(githubActionsFileName));
+  var githubActionsYaml = yaml.load(shell.cat(githubActionsFileName));
   checkGithubActions(MIN_NODE_VERSION, MAX_NODE_VERSION, githubActionsYaml);
 
   console.log('All files look good (this project supports v'


### PR DESCRIPTION
This updates js-yaml to 4.1.0 and swaps out `yaml.safeLoad()` for `yaml.load()` because the `safe*` functions are deprecated starting in 4.0.0 (the "regular" functions are considered safe).