### PR TITLE
chore: update shelljs and drop old node support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,18 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 6
-          - 7
-          - 8
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          - 16
-          - 17
           - 18
           - 19
           - 20

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 commands, providing an easy solution for simple Unix-like, cross-platform
 commands in npm package scripts.
 
-`shx` is proudly tested on every node release since <!-- start minVersion -->`v6`<!-- stop minVersion -->!
+`shx` is proudly tested on every node release since <!-- start minVersion -->`v18`<!-- stop minVersion -->!
 
 ## Difference Between ShellJS and shx
 

--- a/package.json
+++ b/package.json
@@ -56,24 +56,24 @@
     "babel-register": "^6.7.2",
     "concurrently": "^5.3.0",
     "eslint": "^5.16.0",
-    "eslint-import-resolver-node": "0.3.7",
     "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-import-resolver-node": "0.3.7",
     "eslint-plugin-import": "^2.26.0",
     "js-yaml": "^3.12.0",
     "mocha": "^6.2.3",
     "nyc": "^14.1.1",
     "rimraf": "^2.5.2",
     "shelljs-changelog": "^0.2.6",
-    "shelljs-plugin-open": "^0.2.1",
+    "shelljs-plugin-open": "^0.3.0",
     "shelljs-release": "^0.5.2",
     "should": "^13.2.3",
     "watch": "^1.0.2"
   },
   "dependencies": {
     "minimist": "^1.2.6",
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.9.1"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=18"
   }
 }

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml');
 var shell = require('shelljs');
 
 // This is the authoritative list of supported node versions.
-var MIN_NODE_VERSION = 6;
+var MIN_NODE_VERSION = 18;
 var MAX_NODE_VERSION = 22;
 
 function checkReadme(minNodeVersion) {

--- a/src/shx.js
+++ b/src/shx.js
@@ -43,8 +43,7 @@ export function shx(argv) {
   const parsedArgs = minimist(argv.slice(2), { stopEarly: true, boolean: true });
   if (parsedArgs.version) {
     const shxVersion = require('../package.json').version;
-    const shelljsVersion = require('shelljs/package.json').version;
-    console.log(`shx v${shxVersion} (using ShellJS v${shelljsVersion})`);
+    console.log(`shx v${shxVersion}`);
     return EXIT_CODES.SUCCESS;
   }
   const [fnName, ...args] = parsedArgs._;

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -122,7 +122,7 @@ describe('cli', () => {
   describe('global flags', () => {
     it('supports --version', () => {
       const output = cli('--version');
-      output.stdout.should.match(/shx v\S+ \(using ShellJS v\S+\)\n/);
+      output.stdout.should.match(/shx v\S+\n/);
       output.stderr.should.equal('');
       output.code.should.equal(0);
     });
@@ -351,7 +351,7 @@ describe('cli', () => {
     it('works with /g and -i', () => {
       const output = cli('sed', '-i', 's/foo/bar/g', testFileName1);
       const expected = 'bar\nbarsomething\nbarbarsomething\n';
-      output.stdout.should.equal(expected);
+      output.stdout.should.equal('');
       shell.cat(testFileName1).stdout.should.equal(expected);
     });
 


### PR DESCRIPTION
This updates the ShellJS peer dependency to the latest release. This also drops support for all node versions prior to v18 to match ShellJS's version range.

This includes some changes due to the latest shelljs version:

* `shx sed -i` will now run silently. This is compatible with unix behavior. See shelljs/shelljs#959
* `shx --version` no longer prints the ShellJS version. This is a consequence of the switch to an explicit "exports" list in shelljs (see shelljs/shelljs#1195 and shelljs/shelljs#1135).

Test: npm test