### PR TITLE
chore: drop non-LTS node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   - push
   - pull_request
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
@@ -13,35 +11,12 @@ jobs:
       matrix:
         node-version:
           - 18
-          - 19
           - 20
-          - 21
           - 22
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        exclude:
-          - node-version: 6
-            os: macos-latest
-          - node-version: 7
-            os: macos-latest
-          - node-version: 8
-            os: macos-latest
-          - node-version: 9
-            os: macos-latest
-          - node-version: 10
-            os: macos-latest
-          - node-version: 11
-            os: macos-latest
-          - node-version: 12
-            os: macos-latest
-          - node-version: 13
-            os: macos-latest
-          - node-version: 14
-            os: macos-latest
-          - node-version: 15
-            os: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 commands, providing an easy solution for simple Unix-like, cross-platform
 commands in npm package scripts.
 
-`shx` is proudly tested on every node release since <!-- start minVersion -->`v18`<!-- stop minVersion -->!
+`shx` is proudly tested on every LTS node release since <!-- start minVersion -->`v18`<!-- stop minVersion -->!
 
 ## Difference Between ShellJS and shx
 

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -44,7 +44,10 @@ function assertDeepEquals(arr1, arr2, msg) {
 
 function range(start, stop) {
   var ret = [];
-  for (var i = start; i <= stop; i++) {
+  for (var i = start; i <= stop; i += 2) {
+    if (i % 2 !== 0) {
+      console.warn('Warning: testing a non-LTS nodejs release: ' + i);
+    }
     ret.push(i);
   }
   return ret;
@@ -68,7 +71,7 @@ try {
   var githubActionsYaml = yaml.load(shell.cat(githubActionsFileName));
   checkGithubActions(MIN_NODE_VERSION, MAX_NODE_VERSION, githubActionsYaml);
 
-  console.log('All files look good (this project supports v'
+  console.log('All files look good (this project supports LTS releases v'
       + MIN_NODE_VERSION + '-v' + MAX_NODE_VERSION + ')!');
 } catch (e) {
   console.error('Please check the files which declare our Node version');


### PR DESCRIPTION
No change to logic. This drops support for non-LTS versions and it also drops everything before node v18 (this will be required anyway for shelljs v0.9).