### PR TITLE
docs: clarify --silent flag doesn't suppress exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ sub
 $ shx rm -r sub                 # options work as well
 
 $ shx --silent ls fakeFileName  # silence error output
+$ shx --silent ls fakeFileName || shx true  # silence error output and ignore the exit status
 
 $ shx --negate test -d dir      # Negate status code output (e.g., failed commands will now have status 0)
 ```


### PR DESCRIPTION
## Description

Clarifies that the `--silent` flag only suppresses error output, not the exit code. Users in #208 expected `--silent` to also suppress exit codes, leading to confusion in npm scripts.

## Changes

Added one line to the README Usage example:
```bash
$ shx --silent ls fakeFileName || shx true  # silence error output and ignore the exit status
```

This follows the exact suggestion from the maintainer in [#208](https://github.com/shelljs/shx/issues/208#issuecomment-1916715499).

## Related

Fixes #208