### PR TITLE
chore: update codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,20 +13,21 @@ jobs:
           - 20
           - 22
           - 24
+          - 26
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
       - run: npm run check-node-support
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -9,7 +9,7 @@ var shell = require('shelljs');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 20;
-var MAX_NODE_VERSION = 24;
+var MAX_NODE_VERSION = 26;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';


### PR DESCRIPTION
I'm getting gpg signature errors with codecov right now. I'm going to
see if upgrading to v6 addresses the issue (unlikely, but worth a try).
